### PR TITLE
Fix double save files

### DIFF
--- a/game_state.py
+++ b/game_state.py
@@ -1,7 +1,10 @@
 import os
 import json
 
-SAVE_PATH = os.path.join(os.path.dirname(__file__), "save.json")
+# Par défaut, toutes les sauvegardes se trouvent dans le dossier
+# ``home`` à la racine du projet. Cela évite la création accidentelle
+# d'un fichier ``save.json`` supplémentaire à la racine du dépôt.
+SAVE_PATH = os.path.join(os.path.dirname(__file__), "home", "save.json")
 
 
 class GameState:


### PR DESCRIPTION
## Summary
- ensure save files are written only into the `home` folder

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688231b33ea8832dad7857b15c8b700a