### PR TITLE
Add contextual help for commands

### DIFF
--- a/commands/cat.py
+++ b/commands/cat.py
@@ -1,5 +1,11 @@
 import os
 
+# Description utilisée par la commande "help".
+HELP = (
+    "Affiche le contenu d'un fichier."\
+    "\nExemple : cat script.cl"
+)
+
 def run(args, cli):
     if not args:
         print("Utilisation : cat <nom_fichier>")

--- a/commands/create.py
+++ b/commands/create.py
@@ -1,5 +1,10 @@
 import os
 
+HELP = (
+    "Crée un nouveau script .cl."\
+    "\nExemple : create monscript.cl"
+)
+
 
 def run(args, cli):
     if not args:

--- a/commands/edit.py
+++ b/commands/edit.py
@@ -1,5 +1,10 @@
 import os
 
+HELP = (
+    "Édite un fichier ligne par ligne."\
+    "\nExemple : edit monscript.cl"
+)
+
 def run(args, cli):
     if not args:
         print("Utilisation : edit <nom_fichier>")

--- a/commands/exit.py
+++ b/commands/exit.py
@@ -1,3 +1,8 @@
+HELP = (
+    "Quitte le jeu ou la machine distante."\
+    "\nExemple : exit"
+)
+
 def run(args, cli):
     if cli.remote_name:
         print("↩️ Déconnexion de la machine distante.")

--- a/commands/help.py
+++ b/commands/help.py
@@ -1,4 +1,27 @@
+import importlib
+
+HELP = (
+    "Affiche l'aide générale ou celle d'une commande."\
+    "\nExemple : help upgrade"
+)
+
+
 def run(args, cli):
+    if args:
+        cmd = args[0]
+        try:
+            module = importlib.import_module(f"commands.{cmd}")
+        except ModuleNotFoundError:
+            print(f"Commande inconnue : {cmd}")
+            return
+
+        doc = getattr(module, "HELP", None)
+        if doc:
+            print(doc)
+        else:
+            print(f"Aucune aide disponible pour la commande '{cmd}'.")
+        return
+
     state = cli.state
     inventory = state.inventory
 

--- a/commands/idle.py
+++ b/commands/idle.py
@@ -3,6 +3,11 @@ import importlib
 import time
 import threading
 
+HELP = (
+    "Exécute un script en tâche de fond."\
+    "\nExemple : idle monscript.cl"
+)
+
 
 def run(args, cli):
     if not args:

--- a/commands/jobs.py
+++ b/commands/jobs.py
@@ -1,5 +1,10 @@
 import threading
 
+HELP = (
+    "Liste les scripts en cours d'exécution en arrière-plan."\
+    "\nExemple : jobs"
+)
+
 
 def run(args, cli):
     if not cli.background_tasks:

--- a/commands/ls.py
+++ b/commands/ls.py
@@ -1,5 +1,10 @@
 import os
 
+HELP = (
+    "Liste les fichiers du dossier courant."\
+    "\nExemple : ls"
+)
+
 IGNORE_LIST = [
     "save.json",
     # Ajoute ici d'autres fichiers ou dossiers à ignorer

--- a/commands/nmap.py
+++ b/commands/nmap.py
@@ -1,3 +1,8 @@
+HELP = (
+    "Scanne le réseau local (si vous possédez l'outil)."\
+    "\nExemple : nmap"
+)
+
 def run(args, cli):
     if "tool_nmap" not in cli.state.inventory:
         print("❌ Vous n'avez pas la commande 'nmap'. Achetez-la dans le shop.")

--- a/commands/run.py
+++ b/commands/run.py
@@ -2,6 +2,11 @@ import os
 import time
 import importlib
 
+HELP = (
+    "Exécute un script .cl."\
+    "\nExemple : run monscript.cl"
+)
+
 def run(args, cli):
     if not args:
         print("Utilisation : run <nom_fichier>")

--- a/commands/shop.py
+++ b/commands/shop.py
@@ -1,6 +1,11 @@
 import os
 import json
 
+HELP = (
+    "Affiche la boutique pour acheter outils et machines."\
+    "\nExemple : shop"
+)
+
 SHOP_ITEMS = [
     {
         "label": "Machine Linux v1",

--- a/commands/ssh.py
+++ b/commands/ssh.py
@@ -3,6 +3,11 @@ import os
 import json
 from game_state import GameState
 
+HELP = (
+    "Connexion à une machine distante via SSH."\
+    "\nExemple : ssh ma_vm"
+)
+
 def run(args, cli):
     if "tool_ssh" not in cli.state.inventory:
         print("❌ Vous n'avez pas la commande 'ssh'. Achetez-la dans le shop.")

--- a/commands/stop.py
+++ b/commands/stop.py
@@ -1,5 +1,10 @@
 import threading
 
+HELP = (
+    "Arrête un script lancé avec idle."\
+    "\nExemple : stop 1"
+)
+
 
 def run(args, cli):
     if not args:

--- a/commands/upgrade.py
+++ b/commands/upgrade.py
@@ -13,6 +13,11 @@ UPGRADES = [
     }
 ]
 
+HELP = (
+    "Améliore la puissance ou les gains de votre machine."\
+    "\nExemple : upgrade"
+)
+
 def run(args, cli):
     state = cli.get_active_state()
 


### PR DESCRIPTION
## Summary
- add `HELP` descriptions for every command module
- enhance the `help` command to display help for `help <commande>`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688241fec8b0832db955d083bb3cb37b