### PR TITLE
Add purchasable idle module

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Améliorez votre machine, débloquez des commandes (`nmap`, `ssh`, `upgrade`, et
 
 ✅ Terminal sandboxé sécurisé (aucune commande système réelle)  
 ✅ Tutoriel interactif au premier lancement  
-✅ Commandes simulées : `ls`, `cat`, `edit`, `run`, `idle`, `jobs`, `stop`, `create`, `shop`, `ssh`, `exit`, `upgrade`...
+✅ Commandes simulées : `ls`, `cat`, `edit`, `run`, `create`, `shop`, `ssh`, `exit`, `upgrade`...
+✅ Module `idle` (et ses commandes `jobs`/`stop`) à acheter dans la boutique
+   (débloqué après avoir gagné 200$, coût de 50$)
 ✅ Système de fichiers virtuel par utilisateur  
 ✅ Scripts personnalisables en ClidleScript (`makeMoney()`, `upgrade()` etc.)
 ✅ Gain d'argent automatisé avec `power` (vitesse) et `gain` (revenu par appel)  
@@ -96,9 +98,9 @@ python main.py
 | `cat`          | Affiche le contenu d’un fichier                  |
 | `edit`         | Modifie un fichier texte                         |
 | `run`          | Exécute un script `.cl` (ex: `money.cl`)         |
-| `idle`         | Lance un script en tâche de fond                 |
-| `jobs`         | Liste les scripts lancés avec `idle`             |
-| `stop <id>`    | Arrête un script en arrière-plan                 |
+| `idle`         | Lance un script en tâche de fond (après achat)   |
+| `jobs`         | Liste les scripts lancés avec `idle` (après achat) |
+| `stop <id>`    | Arrête un script en arrière-plan (après achat)     |
 | `create`       | Crée un nouveau script `.cl`                     |
 | `shop`         | Ouvre la boutique pour acheter des améliorations|
 | `ssh <nom>`    | Accède à une machine distante                    |

--- a/commands/help.py
+++ b/commands/help.py
@@ -33,9 +33,12 @@ def run(args, cli):
     print("  cat    → Affiche le contenu d’un fichier")
     print("  edit   → Permet de modifier un fichier")
     print("  run    → Exécute un script (.cl)")
-    print("  idle   → Lance un script en tâche de fond")
-    print("  jobs   → Liste les scripts en arrière-plan")
-    print("  stop   → Arrête un script lancé avec 'idle'")
+    if "tool_idle" in inventory:
+        print("  idle   → Lance un script en tâche de fond")
+        print("  jobs   → Liste les scripts en arrière-plan")
+        print("  stop   → Arrête un script lancé avec 'idle'")
+    else:
+        print("  idle/jobs/stop → Achetez le module Idle dans le shop")
     print("  create → Crée un nouveau script .cl")
     print("  shop   → Ouvre la boutique pour acheter des outils")
     print("  exit   → Quitte le jeu")

--- a/commands/idle.py
+++ b/commands/idle.py
@@ -10,6 +10,9 @@ HELP = (
 
 
 def run(args, cli):
+    if "tool_idle" not in cli.state.inventory:
+        print("❌ Vous n'avez pas le module 'idle'. Achetez-le dans le shop.")
+        return
     if not args:
         print("Utilisation : idle <nom_fichier>")
         return

--- a/commands/jobs.py
+++ b/commands/jobs.py
@@ -7,6 +7,9 @@ HELP = (
 
 
 def run(args, cli):
+    if "tool_idle" not in cli.state.inventory:
+        print("❌ Vous n'avez pas le module 'idle'. Achetez-le dans le shop.")
+        return
     if not cli.background_tasks:
         print("Aucun script en arrière-plan.")
         return

--- a/commands/shop.py
+++ b/commands/shop.py
@@ -24,6 +24,13 @@ SHOP_ITEMS = [
         "key": "tool_ssh",
         "desc": "Permet de se connecter à une machine via 'ssh <nom>'.",
         "cost": 10.00
+    },
+    {
+        "label": "Module Idle",
+        "key": "tool_idle",
+        "desc": "Autorise l'usage d'idle, jobs et stop pour lancer des scripts en arrière-plan.",
+        "cost": 50.00,
+        "unlock": 200.0
     }
 ]
 
@@ -32,7 +39,12 @@ def run(args, cli):
     state = cli.state
 
     print("\n🛍️ Boutique :\n")
-    for i, item in enumerate(SHOP_ITEMS, start=1):
+    available_items = [
+        it for it in SHOP_ITEMS
+        if it.get("unlock", 0) <= state.total_money_earned or it["key"] in state.inventory
+    ]
+
+    for i, item in enumerate(available_items, start=1):
         owned = "✅" if item["key"] in state.inventory else ""
         print(f"{i}. {item['label']} - {item['cost']:.2f}$ {owned}")
         print(f"   {item['desc']}")
@@ -49,11 +61,11 @@ def run(args, cli):
         return
 
     index = int(choice) - 1
-    if index < 0 or index >= len(SHOP_ITEMS):
+    if index < 0 or index >= len(available_items):
         print("❌ Numéro invalide.")
         return
 
-    item = SHOP_ITEMS[index]
+    item = available_items[index]
 
     if item["key"] in state.inventory and item["key"] != "vm_linux":
         print("📦 Vous possédez déjà cet objet.")
@@ -106,6 +118,8 @@ def run(args, cli):
     else:
         state.inventory.append(item["key"])
         print(f"✅ Vous avez acheté : {item['label']} !")
+        if item["key"] == "tool_idle":
+            print("Les commandes 'idle', 'jobs' et 'stop' sont maintenant disponibles.")
 
     print(f"💸 Solde restant : {state.balance:.2f}$")
     state.save()

--- a/commands/stop.py
+++ b/commands/stop.py
@@ -7,6 +7,9 @@ HELP = (
 
 
 def run(args, cli):
+    if "tool_idle" not in cli.state.inventory:
+        print("❌ Vous n'avez pas le module 'idle'. Achetez-le dans le shop.")
+        return
     if not args:
         print("Utilisation : stop <id>")
         return


### PR DESCRIPTION
## Summary
- add idle module to shop with unlock at 200$ and cost 50$
- restrict `idle`, `jobs` and `stop` commands until the module is bought
- update help text
- document the feature in README

## Testing
- `python -m py_compile commands/shop.py commands/idle.py commands/jobs.py commands/stop.py commands/help.py`
- `python main.py <<'EOF'
help
exit
EOF`
- `python main.py <<'EOF'
shop
q
exit
EOF`
- updated game state to 200$ and verified idle item appears
- purchased idle and verified help lists the commands

------
https://chatgpt.com/codex/tasks/task_e_6882442c6658832da9d8ceabeb060f0f