### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Build release
+
+on:
+  release:
+    types: [created]
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install PyInstaller
+        run: pip install pyinstaller
+      - name: Build binary
+        run: pyinstaller --onefile --name clidle main.py
+      - name: Upload Linux asset
+        if: github.event_name == 'release' && matrix.os != 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/clidle
+          asset_name: clidle
+          asset_content_type: application/octet-stream
+      - name: Upload Windows asset
+        if: github.event_name == 'release' && matrix.os == 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: dist/clidle.exe
+          asset_name: clidle.exe
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
## Summary
- add workflow to build clidle on tag or release
- upload built binaries as release assets

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68863107989c832dbf0831272f5a44b6